### PR TITLE
refactor, add CLI args, handle different projects

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,193 +1,271 @@
-require('dotenv').config()
+import 'dotenv/config'
+import { Command } from 'commander'
+import { Octokit } from '@octokit/core'
 
-const { Octokit } = require('@octokit/rest')
+class ProjectImporter {
+  constructor(githubToken) {
+    this.githubToken = githubToken
+    this.octokit = new Octokit({auth: this.githubToken})
+  }
 
-const octokit = new Octokit({
-  auth: process.env.GITHUB_AUTH_TOKEN,
-})
-
-// https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#finding-the-node-id-of-an-organization-project
-// To find the project number, look at the project URL
-const getProjectId = async (number) => {
-  const result = await octokit.graphql(
-    `
-    query ($number: Int!) {
-      organization(login: "status-im") {
-        projectNext(number: $number) {
-          id
-        }
-      }
-    }
-  `,
-    {
-      number,
-    }
-  )
-
-  return result.organization.projectNext.id
-}
-
-// https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#finding-the-node-id-of-a-field
-const getProjectFields = async (projectId) => {
-  const result = await octokit.graphql(
-    `
-    query ($projectId: ID!) {
-      node(id: $projectId) {
-        ... on ProjectNext {
-          fields(first: 20) {
+  async getAllReposPage(owner, cursor = null) {
+    const result = await this.octokit.graphql(
+      `
+      query($owner: String!, $cursor: String) {
+        repositoryOwner(login: $owner) {
+          repositories(first: 100, after: $cursor) {
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
             nodes {
-              id
               name
-              settings
+              owner { login }
             }
           }
         }
       }
-    }
-  `,
-    {
-      projectId,
-    }
-  )
-
-  return result.node.fields.nodes
-}
-
-const getStatusField = (fields) => {
-  const { id, settings } = fields.find((item) => item.name === 'Status')
-
-  const value = JSON.parse(settings).options.find(
-    (option) => option.name === 'Todo'
-  ).id
-
-  return {
-    id,
-    value,
+    `,
+      {
+        owner,
+        cursor
+      }
+    )
+    return result
   }
-}
 
-const getPlatformField = (fields, platform) => {
-  const { id, settings } = fields.find((item) => item.name === 'Platform')
-
-  const value = JSON.parse(settings).options.find(
-    (option) => option.name === platform
-  ).id
-
-  return {
-    id,
-    value,
+  async getAllRepos(owner) {
+    let repos = [], cursor = null, data = null
+    do {
+      let result = await this.getAllReposPage(owner, cursor)
+      data = result.repositoryOwner.repositories
+      cursor = data.pageInfo.endCursor
+      repos.push(...data.nodes)
+    } while (data.pageInfo.hasNextPage)
+    return repos
   }
-}
 
-// https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#adding-an-item-to-a-project
-const addProjectItem = async (projectId, nodeId) => {
-  const result = await octokit.graphql(
-    `
-    mutation ($projectId: ID!, $nodeId: ID!) {
-      addProjectNextItem(
-        input: { projectId: $projectId, contentId: $nodeId }
-      ) {
-        projectNextItem {
-          id
+  async getRepoIssuesPage(owner, name, cursor = null) {
+    const result = await this.octokit.graphql(
+      `
+      query($owner: String!, $name: String!, $cursor: String) {
+        repository(owner: $owner, name: $name) {
+          issues(first: 100, after: $cursor) {
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+            nodes {
+              id
+              number
+              title
+              closed
+              assignees(first: 1) {
+                nodes { login }
+              }
+            }
+          }
         }
       }
-    }
-  `,
-    {
-      projectId,
-      nodeId,
-    }
-  )
-
-  return {
-    itemId: result.addProjectNextItem.projectNextItem.id,
+    `,
+      {
+        owner,
+        name,
+        cursor
+      }
+    )
+    return result
   }
-}
 
-// https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#updating-a-single-select-field
-const updateProjectItem = async (projectId, itemId, field) => {
-  await octokit.graphql(
-    `
-    mutation ($projectId: ID!, $itemId: ID!, $fieldId: ID!, $fieldValue: String!) {
-      updateProjectNextItemField(
-        input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: $fieldValue}
-      ) {
-        projectNextItem {
-          id
+  async getRepoIssues(owner, name) {
+    let issues = [], cursor = null, data = null
+    do {
+      let result = await this.getRepoIssuesPage(owner, name, cursor)
+      data = result.repository.issues
+      cursor = data.pageInfo.endCursor
+      issues.push(...data.nodes)
+    } while (data.pageInfo.hasNextPage)
+    return issues
+  }
+
+  // https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#finding-the-node-id-of-an-organization-project
+  // To find the project number, look at the project URL
+  async getProjectId(org, number) {
+    const result = await this.octokit.graphql(
+      `
+      query ($org: String!, $number: Int!) {
+        organization(login: $org) {
+          projectNext(number: $number) {
+            id
+          }
         }
       }
-    }
-  `,
-    {
-      projectId,
-      itemId,
-      fieldId: field.id,
-      fieldValue: field.value,
-    }
-  )
-}
-
-const createProjectItem = async (projectId, nodeId, status, platform) => {
-  const { itemId } = await addProjectItem(projectId, nodeId)
-  await Promise.all([
-    await updateProjectItem(projectId, itemId, status),
-    await updateProjectItem(projectId, itemId, platform),
-  ])
-}
-
-const importRepository = async (projectId, repo, fields) => {
-  // Get field ID and value of Status and Platform
-  const status = getStatusField(fields)
-  const platform = getPlatformField(fields, repo.platform) // "Mobile", "Desktop", "Web"
-
-  // Get all issues, starting from the oldest
-  const result = await octokit.paginate('GET /repos/{owner}/{repo}/issues', {
-    owner: repo.owner,
-    repo: repo.name,
-    state: 'open',
-    filter: 'created',
-    direction: 'asc',
-  })
-
-  for (const item of result) {
-    console.log(`Importing: ${item.id}`)
-
-    await createProjectItem(projectId, item.node_id, status, platform)
-
-    console.log(`Done: ${item.id}`)
-    console.log('--------')
+    `,
+      {
+        org,
+        number: parseInt(number),
+      }
+    )
+    return result.organization.projectNext.id
   }
 
-  // await Promise.all(
-  //   result.map(async (item) => {
-  //     console.log(`Importing issue: ${item.id}`)
-  //     await createProjectItem(projectId, item.node_id, status, platform)
-  //     console.log(`Issue imported: ${item.id}`)
-  //   })
-  // )
+  // https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#finding-the-node-id-of-a-field
+  async getProjectFields(projectId) {
+    const result = await this.octokit.graphql(
+      `
+      query ($projectId: ID!) {
+        node(id: $projectId) {
+          ... on ProjectNext {
+            fields(first: 20) {
+              nodes {
+                id
+                name
+                settings
+              }
+            }
+          }
+        }
+      }
+    `,
+      {
+        projectId,
+      }
+    )
+
+    return result.node.fields.nodes
+  }
+
+  async getFieldOptions(fields, fieldName) {
+    const field = fields.find((item) => item.name === fieldName)
+    if (field === undefined) { return null }
+    const { id, settings } = field
+    const data = JSON.parse(settings)
+    /* map names to objects for easier access */
+    const options = Object.assign({}, ...data.options.map(s => ({[s.name]: s.id})))
+    return { id, options }
+  }
+
+  // https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#adding-an-item-to-a-project
+  async addProjectItem(projectId, nodeId) {
+    const result = await this.octokit.graphql(
+      `
+      mutation ($projectId: ID!, $nodeId: ID!) {
+        addProjectNextItem(
+          input: { projectId: $projectId, contentId: $nodeId }
+        ) {
+          projectNextItem {
+            id
+          }
+        }
+      }
+    `,
+      {
+        projectId,
+        nodeId,
+      }
+    )
+
+    return {
+      itemId: result.addProjectNextItem.projectNextItem.id,
+    }
+  }
+
+  // https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects#updating-a-single-select-field
+  async updateProjectItem(projectId, itemId, field) {
+    await this.octokit.graphql(
+      `
+      mutation ($projectId: ID!, $itemId: ID!, $fieldId: ID!, $fieldValue: String!) {
+        updateProjectNextItemField(
+          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: $fieldValue}
+        ) {
+          projectNextItem {
+            id
+          }
+        }
+      }
+    `,
+      {
+        projectId,
+        itemId,
+        fieldId: field.id,
+        fieldValue: field.value,
+      }
+    )
+  }
+
+  async createProjectItem(projectId, nodeId, fields) {
+    const { itemId } = await this.addProjectItem(projectId, nodeId)
+    for (const field of fields) {
+      await this.updateProjectItem(projectId, itemId, field)
+    }
+  }
+
+  issueStatusName(issue) {
+    if (issue.closed) { return 'Done' }
+    else if (issue.assignees.nodes.length > 0) { return 'In Progress' }
+    else { return 'Todo' }
+  }
+
+  repoPlatformName(repo) {
+    const repoToPlatform = {
+      'status-react': 'Mobile',
+      'status-desktop': 'Desktop',
+      'status-web': 'Web',
+    }
+    return repoToPlatform[repo.name]
+  }
+
+  async importRepository(projectId, repo, fields, dryRun) {
+    // Get field ID and value of Status and Platform
+    const status = await this.getFieldOptions(fields, 'Status')
+    const platform = await this.getFieldOptions(fields, 'Platform')
+
+    const issues = await this.getRepoIssues(repo.owner.login, repo.name)
+
+    for (const issue of issues) {
+      console.log(` > ${repo.owner.login}/${repo.name}#${issue.number} - ${issue.title}`)
+      if (dryRun) { continue }
+      let fields = []
+      if (status) {
+        fields.push({ id: status.id, value: status.options[this.issueStatusName(issue)] })
+      }
+      if (platform) {
+        fields.push({ id: platform.id, value: platform.options[this.repoPlatformName(repo)] })
+      }
+      await this.createProjectItem(projectId, issue.id, fields)
+    }
+  }
 }
 
-// To find the project number, look at the project URL
-const PROJECT_NUMBER = '<PROJECT_NUMBER_FROM_URL>'
+const parseOpts = () => {
+  const program = new Command()
 
-const repos = [
-  { owner: 'status-im', name: 'status-react', platform: 'Mobile' },
-  { owner: 'status-im', name: 'status-desktop', platform: 'Desktop' },
-  { owner: 'status-im', name: 'status-web', platform: 'Web' },
-]
+  program
+    .requiredOption('-t, --github-token <token>', 'API token for GitHub', process.env.GITHUB_AUTH_TOKEN)
+    .requiredOption('-o, --github-org <name>', 'Name of GitHub Organization', 'status-im')
+    .requiredOption('-p, --project-number <number>', 'Number of GitHub Project from URL')
+    .option('-r, --repos-regex <regex>', 'Regex to match repos', '^status-(react|desktop|web)$')
+    .option('-d, --dry-run', 'Only list issues, do not import', false)
+    .parse()
+
+  return program.opts()
+}
 
 const main = async () => {
-  // Retrieve GitHub Project ID
-  const projectId = await getProjectId(PROJECT_NUMBER)
+  const opts = parseOpts()
 
-  // Retrieve GitHub Project fields
-  const fields = await getProjectFields(projectId)
+  const pi = new ProjectImporter(opts.githubToken)
+  const projectId = await pi.getProjectId(opts.githubOrg, opts.projectNumber)
+  const fields = await pi.getProjectFields(projectId)
+
+  let repos = await pi.getAllRepos(opts.githubOrg)
+  if (opts.reposRegex) {
+    repos = repos.filter(repo => repo.name.match(opts.reposRegex))
+  }
 
   for (const repo of repos) {
-    console.log(`Importing ${repo.name}`)
-    await importRepository(projectId, repo, fields)
-    console.log(`Done ${repo.name}`)
-    console.log('--------')
+    //console.log(` * ${repo.owner.login}/${repo.name}`)
+    await pi.importRepository(projectId, repo, fields, opts.dryRun)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "github-projects-scripts",
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "license": "MIT",
   "dependencies": {
     "@octokit/core": "^3.6.0",
     "@octokit/rest": "^18.12.0",
     "@octokit/webhooks": "^9.23.0",
+    "commander": "^9.2.0",
     "dotenv": "^16.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,6 +141,11 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+commander@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
+  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
+
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"


### PR DESCRIPTION
I added CLI flags so this could be easily re-used:
```log
 > node import.js --help  
Usage: import [options]

Options:
  -t, --github-token <token>     API token for GitHub
  -o, --github-org <name>        Name of GitHub Organization (default: "status-im")
  -p, --project-number <number>  Number of GitHub Project from URL
  -r, --repos-regex <regex>      Regex to match repos (default: "^status-(react|desktop|web)$")
  -d, --dry-run                  Only list issues, do not import (default: false)
  -h, --help                     display help for command
```

I also wanted to import Infra issues to my own Project: https://github.com/orgs/status-im/projects/73
And managed do do this using:
```sh
node import.js -p 73 -r '^infra-.*$'
```
I also dropped use of REST API to fetch issues and used GraphQL instead.